### PR TITLE
fix: asset example payload relationships and jsonld contexts formatting

### DIFF
--- a/jsonld-contexts/sedimark-ai-model-asset.jsonld
+++ b/jsonld-contexts/sedimark-ai-model-asset.jsonld
@@ -16,6 +16,6 @@
     "outputParameters":	"https://sedimark.github.io/ontology#outputParameters",
     "hasTrainingDataset":	"https://sedimark.github.io/ontology#hasTrainingDataset",
     "hasArchitecture":	"https://sedimark.github.io/ontology#hasArchitecture",
-    "datasetProcessing":	"https://sedimark.github.io/ontology#datasetProcessing",
+    "datasetProcessing":	"https://sedimark.github.io/ontology#datasetProcessing"
   }
 }

--- a/jsonld-contexts/sedimark-asset.jsonld
+++ b/jsonld-contexts/sedimark-asset.jsonld
@@ -18,7 +18,7 @@
     "endpointURL": "http://www.w3.org/ns/dcat#endpointURL",
     "endpointDescription": "http://www.w3.org/ns/dcat#endpointDescription",
     "geometry": "http://www.w3.org/ns/locn#geometry",
-    "image": "https://sedimark.github.io/ontology#	image",
+    "image": "https://sedimark.github.io/ontology#image",
     "relatedAsset": "https://sedimark.github.io/ontology#relatedAsset",
     "processingSteps": "https://sedimark.github.io/ontology#processingSteps"
   }

--- a/jsonld-contexts/sedimark-participant.jsonld
+++ b/jsonld-contexts/sedimark-participant.jsonld
@@ -5,6 +5,6 @@
     "account": "https://sedimark.github.io/ontology#account",
     "openid": "https://sedimark.github.io/ontology#openid",
     "mbox": "https://sedimark.github.io/ontology#mbox",
-    "homepage": "https://sedimark.github.io/ontology#homepage",
+    "homepage": "https://sedimark.github.io/ontology#homepage"
   }
 }

--- a/jsonld-contexts/sedimark-service-asset.jsonld
+++ b/jsonld-contexts/sedimark-service-asset.jsonld
@@ -4,7 +4,6 @@
     "endpointURL": "http://www.w3.org/ns/dcat#endpointURL",
     "endpointDescription": "http://www.w3.org/ns/dcat#endpointDescription",
     "servesDataset":	"http://www.w3.org/ns/dcat#servesDataset",
-    "serviceConfig": "https://sedimark.github.io/ontology#serviceConfig",
-
+    "serviceConfig": "https://sedimark.github.io/ontology#serviceConfig"
   }
 }

--- a/payload-example/asset.jsonld
+++ b/payload-example/asset.jsonld
@@ -54,7 +54,7 @@
     "value": "https://my.endpoint/url"
   },
   "endpointDescription": {
-    "type": "GeoProperty",
+    "type": "Property",
     "value": "this is what my endpoint do"
   },
   "geometry": {

--- a/payload-example/asset.jsonld
+++ b/payload-example/asset.jsonld
@@ -7,7 +7,7 @@
   },
   "creator": {
     "type": "Relationship",
-    "value": "id:of:the:creator"
+    "object": "urn:ngsi-ld:Participant:MyParticipantId"
   },
   "description": {
     "type": "Property",
@@ -15,7 +15,7 @@
   },
   "publisher": {
     "type": "Relationship",
-    "value": "id:of:the:publisher"
+    "object": "urn:ngsi-ld:Participant:MyParticipantId"
   },
   "issued": {
     "type": "Property",

--- a/payload-example/asset.jsonld
+++ b/payload-example/asset.jsonld
@@ -58,15 +58,15 @@
     "value": "this is what my endpoint do"
   },
   "geometry": {
-  "type": "GeoProperty",
-  "value": {
-    "type": "Point",
-    "coordinates": [
-      1.5,
-      1.5
-    ]
-  }
-},
+    "type": "GeoProperty",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        1.5,
+        1.5
+      ]
+    }
+  },
   "image": {
     "type": "Property",
     "value": "https://image.com/my/image"


### PR DESCRIPTION
Hi there! As I was experimenting with the NGSI-LD broker and the context provided in this repo, I encountered a few issues. This PR resolves some of them, including:
- `Relationship` requiring `object` rather than `value` field ( 6d3edce4f09c )
- change `endpointDescription` to `Property` ( 01ef1afc10df )
- (minor) reformatting of jsonld context to enable them to be parsed as json (this is useful to render them in a web browser or with tools like `jq`)

However, 2 issues subsists:
1. it seems that the context is not reachable. For instance, trying:
```bash
curl -X POST http://localhost:8080/ngsi-ld/v1/entities -H "Content-Type: application/json" -H 'Link: <https://sedimark.github.io/broker/jsonld-contexts/sedimark-compound.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -d @payload-example/participant.jsonld
```
leads to:
```bash
{
  "type": "https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable",
  "title": "Unable to load remote context (cause was: JsonLdError[code=There was a problem encountered loading a remote context [code=LOADING_REMOTE_CONTEXT_FAILED]., message=There was a problem encountered loading a remote context [code=LOADING_REMOTE_CONTEXT_FAILED].])",
  "status": 503,
  "detail": "If you have difficulty identifying the exact cause of the error, please check the list of some usual causes on https://stellio.readthedocs.io/en/latest/TROUBLESHOOT.html . If the error is still not clear or if you think it is a bug, feel free to open an issue on https://github.com/stellio-hub/stellio-context-broker",
  "instance": "/ngsi-ld/v1/entities"
}
```
  You need to remove the _Link_ header to make the request go through.

2. if you try to dump the provided asset example, even with the aforementioned fixes, an error will still be raised because of the `geometry` field. More precisely, running: 
```bash
curl -X POST http://localhost:8080/ngsi-ld/v1/entities -H "Content-Type: application/json" -d @payload-example/asset.jsonld 
```
leads to:
```bash
{
  "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
  "title": "GeoProperty https://purl.org/geojson/vocab#geometry has an instance without a value",
  "status": 400,
  "detail": "If you have difficulty identifying the exact cause of the error, please check the list of some usual causes on https://stellio.readthedocs.io/en/latest/TROUBLESHOOT.html . If the error is still not clear or if you think it is a bug, feel free to open an issue on https://github.com/stellio-hub/stellio-context-broker",
  "instance": "/ngsi-ld/v1/entities"
}
```

@thomasBousselin Maybe I am doing something wrong ? 